### PR TITLE
Coffeescript has deprecated the hyphenated package, see https://www.n…

### DIFF
--- a/Public/Install-Hubot.ps1
+++ b/Public/Install-Hubot.ps1
@@ -35,7 +35,7 @@
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 
     Write-Verbose -Message "Installing CoffeeScript"
-    Start-Process -FilePath npm -ArgumentList "install -g coffee-script" -Wait -NoNewWindow
+    Start-Process -FilePath npm -ArgumentList "install -g coffeescript" -Wait -NoNewWindow
 
     Write-Verbose -Message "Installing Hubot Generator"
     Start-Process -FilePath npm -ArgumentList "install -g yo generator-hubot" -Wait -NoNewWindow

--- a/Public/Start-Hubot.ps1
+++ b/Public/Start-Hubot.ps1
@@ -108,7 +108,7 @@ function Start-Hubot
 
         $processParams = @{
             FilePath = 'cmd'
-            ArgumentList = "/c forever start --uid ""$($Config.BotName)"" --pidFile ""$($Config.PidPath)"" --verbose --append -l ""$($Config.LogPath)\$($fileDate)_$($Config.BotName).log"" --sourceDir ""$($Config.BotPath)"" --workingDir ""$($Config.BotPath)"" --minUptime 100 --spinSleepTime 100 .\node_modules\coffee-script\bin\coffee .\node_modules\hubot\bin\hubot $($Config.ArgumentList)"
+            ArgumentList = "/c forever start --uid ""$($Config.BotName)"" --pidFile ""$($Config.PidPath)"" --verbose --append -l ""$($Config.LogPath)\$($fileDate)_$($Config.BotName).log"" --sourceDir ""$($Config.BotPath)"" --workingDir ""$($Config.BotPath)"" --minUptime 100 --spinSleepTime 100 .\node_modules\coffeescript\bin\coffee .\node_modules\hubot\bin\hubot $($Config.ArgumentList)"
             NoNewWindow = $true
             WorkingDirectory = $Config.BotPath
             PassThru = $true

--- a/Public/Start-Hubot.ps1
+++ b/Public/Start-Hubot.ps1
@@ -10,7 +10,7 @@
 #>
 function Start-Hubot
 {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     Param
     (
         # Path to the PoshHubot Configuration File
@@ -95,13 +95,19 @@ function Start-Hubot
 
         # Do an npm install incase there are any new modules
         Write-Verbose -Message "Running npm install"
-        Start-Process -FilePath npm -ArgumentList "install" -Wait -NoNewWindow -WorkingDirectory $Config.BotPath
+        if ($PSCmdlet.ShouldProcess("ShouldProcess command: 'Start-Process -FilePath npm -ArgumentList ""install"" -Wait -NoNewWindow -WorkingDirectory $Config.BotPath'")) 
+        {
+            Start-Process -FilePath npm -ArgumentList "install" -Wait -NoNewWindow -WorkingDirectory $Config.BotPath
+        }
 
         # Add the environment variables from the config
         ForEach ($envVar in $Config.EnvironmentVariables.psobject.Properties)
         {
             Write-Verbose "Setting Environment Variable $($envVar.Name)"
-            New-Item -Path Env:\ -Name $envVar.Name -Value $envVar.Value -Force | Out-Null
+            if ($PSCmdlet.ShouldProcess("ShouldProcess command: 'New-Item -Path Env:\ -Name $envVar.Name -Value $envVar.Value -Force | Out-Null'.")) 
+            {
+                New-Item -Path Env:\ -Name $envVar.Name -Value $envVar.Value -Force | Out-Null
+            }
         }
 
         $fileDate = Get-Date -format yyyy-M-ddTHHmmss
@@ -117,23 +123,26 @@ function Start-Hubot
         Write-Verbose "Start Command:"
         Write-Verbose $processParams.ArgumentList
 
-        # Start Hubot
-        $proc = Start-Process @processParams
-
-        # Wait for the command prompt to close
-        $proc.WaitForExit()
-
-        # Wait a few seconds for pid to be created
-        Start-Sleep -Seconds 2
-
-        # Verify bot started ok by checking if the pid file exists
-        if (Test-HubotRunning -ConfigPath $ConfigPath)
+        
+        if ($PSCmdlet.ShouldProcess("ShouldProcess: Start Hubot and check that it is running.")) 
         {
-            return "Your bot $($Config.BotName) is running."
-        }
-        else
-        {
-            throw "Could not find pid file at $($Config.PidPath). Check $($Config.LogPath) for logs."
+            # Start Hubot
+            $proc = Start-Process @processParams
+            # Wait for the command prompt to close
+            $proc.WaitForExit()
+
+            # Wait a few seconds for pid to be created
+            Start-Sleep -Seconds 2
+
+            # Verify bot started ok by checking if the pid file exists
+            if (Test-HubotRunning -ConfigPath $ConfigPath)
+            {
+                return "Your bot $($Config.BotName) is running."
+            }
+            else
+            {
+                throw "Could not find pid file at $($Config.PidPath). Check $($Config.LogPath) for logs."
+            }
         }
     }
 }

--- a/Tests/Unit/PoshHubot.Tests.ps1
+++ b/Tests/Unit/PoshHubot.Tests.ps1
@@ -77,7 +77,7 @@ $config = @"
         }
 
         $npmInstalls = @(
-            'install -g coffee-script'
+            'install -g coffeescript'
             'install -g yo generator-hubot'
             'install -g forever'
         )


### PR DESCRIPTION
The package coffee-script is deprecated and npm pulls in `coffeescript` rather than `coffee-script`.  See error below.
<img width="581" alt="error" src="https://user-images.githubusercontent.com/8420128/62827663-4c89cb00-bb99-11e9-9519-ab1512ed5330.png">

I changed the path and it seems work nicely now.

Great module, by the way!  The Hubot documentation for how to get Hubot working on Windows is broken, so this was my first time getting it working, with this tool.  I am planning to put in a pull-request for doc changes to Hubot as well.  Keep up the great work on this repo.